### PR TITLE
KP-725 [Zip] method zip - takes paths separated by a space, not one-per-line

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ async function zip(action) {
 
   const archiver = new Archiver(pathToArchive);
 
-  const targetsArray = pathToTargets.split(" ");
+  const targetsArray = pathToTargets.split("\n");
   for (let i = 0; i < targetsArray.length; i += 1) {
     archiver.add(targetsArray[i]);
   }

--- a/config.json
+++ b/config.json
@@ -23,7 +23,7 @@
         {
           "name": "TARGETS",
           "viewName": "Paths to zip",
-          "description": "Paths of files and directories to include (space separated)",
+          "description": "Paths of files and directories to include, one per line.",
           "type": "string",
           "required": true,
           "placeholder": "/home/username/file1.log /home/username/datadir",


### PR DESCRIPTION
[**KP-725 in Jira**](https://kaholo.atlassian.net/browse/KP-725)